### PR TITLE
chore: add link to configuration file in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Welcome! We have a collection of demo apps written to help you get a head start 
 Just like any Flutter app, an atPlatform application requires a little bit of setup before you can get started. Here are those steps:
 
 1. Add the service file to your app: You can simply copy this service file from the `at_hello_world` application. This file contains helper methods that allow you to implement atProtocol functionality with just a couple of lines of code.
-2. Add the configuration file to your app: Again, feel free to copy this from the `at_hello_world` application. This file contains variables that allow you to use the virtual environment. Make sure that the `ROOT_DOMAIN` string is set to `vip.ve.atsign.zone` and you have a unique name for the `NAMESPACE` of your app!
+2. Add the configuration file to your app: Again, feel free to copy [this file](at_hello_world/lib/utils/constants.dart) from the `at_hello_world` application. This file contains variables that allow you to use the virtual environment. Make sure that the `ROOT_DOMAIN` string is set to `vip.ve.atsign.zone` and you have a unique name for the `NAMESPACE` of your app!
 3. Copy the dependencies from the `at_hello_world` pubspec.yaml file and put them into your project.
 
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Welcome! We have a collection of demo apps written to help you get a head start 
 
 Just like any Flutter app, an atPlatform application requires a little bit of setup before you can get started. Here are those steps:
 
-1. Add the service file to your app: You can simply copy this service file from the `at_hello_world` application. This file contains helper methods that allow you to implement atProtocol functionality with just a couple of lines of code.
+1. Add the service file to your app: You can simply copy [this](at_hello_world/lib/service/client_sdk_service.dart) service file from the `at_hello_world` application. This file contains helper methods that allow you to implement atProtocol functionality with just a couple of lines of code.
 2. Add the configuration file to your app: Again, feel free to copy [this file](at_hello_world/lib/utils/constants.dart) from the `at_hello_world` application. This file contains variables that allow you to use the virtual environment. Make sure that the `ROOT_DOMAIN` string is set to `vip.ve.atsign.zone` and you have a unique name for the `NAMESPACE` of your app!
 3. Copy the dependencies from the `at_hello_world` pubspec.yaml file and put them into your project.
 


### PR DESCRIPTION
**- What I did**
Added a link to the configuration and the service files mentioned in the README paragraphs below. As someone new to Flutter, I wasn't sure where these files are usually kept, so I thought it's helpful to link users directly to it.

https://github.com/atsign-foundation/at_demos/blob/76f9961ce3d0805c967d7f77906f0d354a26d358/README.md?plain=1#L19-L20

**- How I did it**
Links to both files were added as relative links with minimal rephrasing of the existing text.

For the service file, I looked for a file that seemed to contain helper methods to allow users to implement atProtocol functionality. If this is not the right file, please let me know.

For the configuration file, I searched for a file with the variables mentioned above: `ROOT_DOMAIN` and `NAMESPACE`. It had the relative path: `at_hello_world/lib/utils/constants.dart`.

**- How to verify it**
Please confirm these are the right files. You can click the links to confirm they work.

If I missed something or need to do more, please let me know. 

**- Description for the changelog**
Add a link to the configuration and the service files mentioned in the README.