### PR TITLE
docs: add semantic PR, conventional commit info, link to .github docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ to update the Markdown file, and start the
 [pull request](https://help.github.com/articles/about-pull-requests/) process.
 Use the preview tab in GitHub to make sure that it is properly
 formatted before committing. Please follow the
-[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
+[conventional commits](https://www.conventionalcommits.org) format.
 A pull request will cause integration tests to run automatically, so please review
 the results of the pipeline and correct any mistakes that are reported.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,8 @@ For small changes, especially documentation, you can simply use the "Edit" butto
 to update the Markdown file, and start the
 [pull request](https://help.github.com/articles/about-pull-requests/) process.
 Use the preview tab in GitHub to make sure that it is properly
-formatted before committing.
+formatted before committing. Please follow the
+[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/) format.
 A pull request will cause integration tests to run automatically, so please review
 the results of the pipeline and correct any mistakes that are reported.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,14 +13,15 @@ For small changes, especially documentation, you can simply use the "Edit" butto
 to update the Markdown file, and start the
 [pull request](https://help.github.com/articles/about-pull-requests/) process.
 Use the preview tab in GitHub to make sure that it is properly
-formatted before committing. Please follow the
-[conventional commits](https://www.conventionalcommits.org) format.
+formatted before committing. Please use conventional commits and follow the semantic PR format as documented 
+[here](https://github.com/atsign-foundation/.github/blob/trunk/atGitHub.md#semantic-prs).
 A pull request will cause integration tests to run automatically, so please review
 the results of the pipeline and correct any mistakes that are reported.
 
 If you plan to contribute often or have a larger change to make, it is best to
 setup an environment for contribution, which is what the rest of these guidelines
-describe.
+describe. The atsign-foundation GitHub organization's conventions and configurations are documented
+[here](https://github.com/atsign-foundation/.github/blob/trunk/atGitHub.md).
 
 ## Development Environment Setup
 


### PR DESCRIPTION
**- What I did**
I added a mention about using conventional commits in CONTRIBUTING.md, and included a link to the relevant website (`https://www.conventionalcommits.org`). I did this because I saw that #50 did not use conventional commits and one of the maintainers [suggested](https://github.com/atsign-foundation/at_demos/pull/50#pullrequestreview-1084786159) it's best to use conventional commits in the future.

**- How I did it**
I added an instruction about conventional commits and the website `https://www.conventionalcommits.org`

**- How to verify it**
Check the Markdown preview and click to link to confirm it works.
If I missed something or need to change the wording, please let me know. I wasn't sure if it's an absolute requirement, so I phrased it more loosely. If it is a strict requirement, maybe it's better to use something like `Contributors must follow the conventional commits standard`.

**- Description for the changelog**
Add conventional commits info to CONTRIBUTING.md