### PR TITLE
fix: modified at_demo_data version to 1.0.1

### DIFF
--- a/at_demo_data/CHANGELOG.md
+++ b/at_demo_data/CHANGELOG.md
@@ -1,9 +1,6 @@
-## 1.0.2
-- **Feat**: Added demo credentials for apkam symmetric key
-## 1.0.1+1
-- **Chore**: Updated documentation.
-
 ## 1.0.1
+- **Feat**: Added demo credentials for apkam symmetric key
+- **Chore**: Updated documentation.
 - **Feat**: Added atkey files for demo atsigns.
 
 ## 1.0.0

--- a/at_demo_data/pubspec.yaml
+++ b/at_demo_data/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://www.atsign.dev
 documentation: https://atsign.dev/docs/
 repository: https://github.com/atsign-foundation/at_demos
 
-version: 1.0.2
+version: 1.0.1
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
**- What I did**
- modified version of at_demo_data to 1.0.1
**- How I did it**
- there were versions in changelog that were not published. pub publish is throwing a warning. so modified version to 1.0.1
- modified pubspec and changelog.md
**- How to verify it**
n/a