### PR TITLE
fix: Unnecessary null check on cmd line args

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -46,12 +46,11 @@ jobs:
           dart pub get
           dart analyze
 
-      # TODO uncomment once warning is fixed
-      #- name: Install dependencies and run analyze - at_data_share
-      #  working-directory: ./at_data_share/
-      #  run: |
-      #    dart pub get
-      #    dart analyze
+      - name: Install dependencies and run analyze - at_data_share
+        working-directory: ./at_data_share/
+        run: |
+          dart pub get
+          dart analyze
 
       # Runs osv-scanner to find any vulnerable Dart dependencies
       # It needs to look at pubspec.lock files, which is why it's
@@ -62,4 +61,4 @@ jobs:
           osv-scanner --lockfile=./mwc_demo/dart/iot_sender/pubspec.lock
           osv-scanner --lockfile=./at_notifications/pubspec.lock
           osv-scanner --lockfile=./at_demo_data/pubspec.lock
-          # osv-scanner --lockfile=./at_data_share/pubspec.lock
+          osv-scanner --lockfile=./at_data_share/pubspec.lock

--- a/at_data_share/lib/src/util/command_line_parser.dart
+++ b/at_data_share/lib/src/util/command_line_parser.dart
@@ -8,7 +8,7 @@ class CommandLineParser {
   ArgResults getParserResults(List<String> arguments, ArgParser parser) {
     var results;
     try {
-      if (arguments != null && arguments.isNotEmpty) {
+      if (arguments.isNotEmpty) {
         results = parser.parse(arguments);
         if (results.options.length != parser.options.length) {
           throw ArgParserException('Invalid Arguments \n' + parser.usage);


### PR DESCRIPTION
Fixes #145 

**- What I did**

Removed unnecessary null check that was causing a `dart analyze` warning and reinstated static analysis for the package

**- How to verify it**

CI against this PR

**- Description for the changelog**

fix: Unnecessary null check on cmd line args