### PR TITLE
feat: update CMakeLists.txt

### DIFF
--- a/demos/get_started_c/0-my-first-c-app/CMakeLists.txt
+++ b/demos/get_started_c/0-my-first-c-app/CMakeLists.txt
@@ -5,14 +5,13 @@ project(my_first_c_app)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)

--- a/demos/get_started_c/1-authentication/CMakeLists.txt
+++ b/demos/get_started_c/1-authentication/CMakeLists.txt
@@ -5,14 +5,14 @@ project(1-authentication)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)
+

--- a/demos/get_started_c/2a-create-public-atkey/CMakeLists.txt
+++ b/demos/get_started_c/2a-create-public-atkey/CMakeLists.txt
@@ -5,14 +5,14 @@ project(2a-create-public-atkey)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)
+

--- a/demos/get_started_c/2b-create-self-atkey/CMakeLists.txt
+++ b/demos/get_started_c/2b-create-self-atkey/CMakeLists.txt
@@ -5,14 +5,13 @@ project(2b-self-atkey)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)

--- a/demos/get_started_c/2c-create-shared-atkey/CMakeLists.txt
+++ b/demos/get_started_c/2c-create-shared-atkey/CMakeLists.txt
@@ -5,14 +5,13 @@ project(2c-shared-atkey)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)

--- a/demos/get_started_c/2d-create-atkey-with-metadata/CMakeLists.txt
+++ b/demos/get_started_c/2d-create-atkey-with-metadata/CMakeLists.txt
@@ -5,14 +5,14 @@ project(2d-atkey-with-metadata)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)
+

--- a/demos/get_started_c/3a-put-public-key/CMakeLists.txt
+++ b/demos/get_started_c/3a-put-public-key/CMakeLists.txt
@@ -5,14 +5,13 @@ project(3a-put-public-atkey)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)

--- a/demos/get_started_c/3b-put-self-atkey/CMakeLists.txt
+++ b/demos/get_started_c/3b-put-self-atkey/CMakeLists.txt
@@ -5,14 +5,13 @@ project(3b-put-self-atkey)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)

--- a/demos/get_started_c/3c-put-shared-atkey/CMakeLists.txt
+++ b/demos/get_started_c/3c-put-shared-atkey/CMakeLists.txt
@@ -5,14 +5,14 @@ project(3c-put-shared-atkey)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)
+

--- a/demos/get_started_c/3d-get-public-atkey/CMakeLists.txt
+++ b/demos/get_started_c/3d-get-public-atkey/CMakeLists.txt
@@ -5,14 +5,13 @@ project(3d-get-public-atkey)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)

--- a/demos/get_started_c/3e-get-self-atkey/CMakeLists.txt
+++ b/demos/get_started_c/3e-get-self-atkey/CMakeLists.txt
@@ -5,14 +5,13 @@ project(3e-get-self-atkey)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)

--- a/demos/get_started_c/3f-get-shared-atkey/CMakeLists.txt
+++ b/demos/get_started_c/3f-get-shared-atkey/CMakeLists.txt
@@ -5,14 +5,13 @@ project(3f-get-shared-atkey)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)

--- a/demos/get_started_c/3g-delete-atkey/CMakeLists.txt
+++ b/demos/get_started_c/3g-delete-atkey/CMakeLists.txt
@@ -5,14 +5,14 @@ project(3g-delete-atkey)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)
+

--- a/demos/get_started_c/4a-monitor/CMakeLists.txt
+++ b/demos/get_started_c/4a-monitor/CMakeLists.txt
@@ -5,14 +5,13 @@ project(4a-monitor)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)

--- a/demos/get_started_c/4b-notify/CMakeLists.txt
+++ b/demos/get_started_c/4b-notify/CMakeLists.txt
@@ -5,14 +5,13 @@ project(4b-notify)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)

--- a/demos/get_started_c/5a-hooks/CMakeLists.txt
+++ b/demos/get_started_c/5a-hooks/CMakeLists.txt
@@ -5,14 +5,13 @@ project(5a-hooks)
 include(FetchContent)
 
 FetchContent_Declare(
-  atclient
-  URL https://github.com/atsign-foundation/at_c/releases/download/v0.1.0/at_c-v0.1.0.tar.gz
-  URL_HASH SHA256=494a4960dedc45484a0078db4c388cd592efdebde45e40bdded5c2b9c587b146
-  SOURCE_SUBDIR packages/atclient
+  atsdk
+  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
+  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
 )
 
-FetchContent_MakeAvailable(atclient)
+FetchContent_MakeAvailable(atsdk)
 
 add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)
 
-target_link_libraries(main PRIVATE atclient atlogger atchops mbedtls mbedcrypto mbedx509 cjson)
+target_link_libraries(main PRIVATE atclient)


### PR DESCRIPTION
**- What I did**
- Changed the FetchContent for the C demos

New way

```
FetchContent_Declare(
  atsdk
  URL https://github.com/atsign-foundation/at_c/archive/refs/tags/v0.1.0.tar.gz
  URL_HASH SHA256=7ca4215a473037ca07bef362b852291b0a1cf4e975d24d373d58ae9c1df832bc
)

FetchContent_MakeAvailable(atsdk)

add_executable(main ${CMAKE_CURRENT_LIST_DIR}/main.c)

target_link_libraries(main PRIVATE atclient)

```

- For now, let's have our instructions download from the `Source code `tar.gz` until this [work](https://github.com/atsign-foundation/at_c/issues/378) is completed and released.


**- How to verify it**
After investigation with @sitaram-kalluri , the original way we installed things didn't work. The reason it didn't work was cause the `libatclient.a` and other libs were not installed in `/usr/local/lib` which was weird behaviour.

To verify it, I've deleted my installed libs:

```
jeremy@raspberrypi8:/usr/local/lib $ ls -l
total 8
drwxr-xr-x 2 root root 4096 Aug  6 12:16 pkgconfig
drwxr-xr-x 3 root root 4096 Jul  3 20:05 python3.11
jeremy@raspberrypi8:/usr/local/lib $ 
```

Then I re-ran the examples with the `New way`:

```
jeremy@raspberrypi8:~/GitHub/at_demos/demos/get_started_c/0-my-first-c-app $ cmake -S . -B build && cmake --build build && ./build/main
-- The C compiler identification is GNU 12.2.0
-- The CXX compiler identification is GNU 12.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- [ATSDK] ATSDK_AS_SUBPROJECT: ON
-- Building atlogger
-- [ATLOGGER] ATLOGGER_AS_SUBPROJECT: ON
-- Building atchops
-- [ATCHOPS] ATCHOPS_AS_SUBPROJECT: ON
-- [MbedTLS] fetching package...
-- Found Python3: /usr/bin/python3 (found version "3.11.2") found components: Interpreter 
-- Performing Test C_COMPILER_SUPPORTS_WFORMAT_SIGNEDNESS
-- Performing Test C_COMPILER_SUPPORTS_WFORMAT_SIGNEDNESS - Success
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE  
-- [uuid4] fetching package...
-- Building atclient
-- [ATCLIENT] ATCLIENT_AS_SUBPROJECT: ON
-- [cjson] fetching package...
-- Performing Test FLAG_SUPPORTED_stdc89
-- Performing Test FLAG_SUPPORTED_stdc89 - Success
-- Performing Test FLAG_SUPPORTED_pedantic
-- Performing Test FLAG_SUPPORTED_pedantic - Success
-- Performing Test FLAG_SUPPORTED_Wall
-- Performing Test FLAG_SUPPORTED_Wall - Success
-- Performing Test FLAG_SUPPORTED_Wextra
-- Performing Test FLAG_SUPPORTED_Wextra - Success
-- Performing Test FLAG_SUPPORTED_Werror
-- Performing Test FLAG_SUPPORTED_Werror - Success
-- Performing Test FLAG_SUPPORTED_Wstrictprototypes
-- Performing Test FLAG_SUPPORTED_Wstrictprototypes - Success
-- Performing Test FLAG_SUPPORTED_Wwritestrings
-- Performing Test FLAG_SUPPORTED_Wwritestrings - Success
-- Performing Test FLAG_SUPPORTED_Wshadow
-- Performing Test FLAG_SUPPORTED_Wshadow - Success
-- Performing Test FLAG_SUPPORTED_Winitself
-- Performing Test FLAG_SUPPORTED_Winitself - Success
-- Performing Test FLAG_SUPPORTED_Wcastalign
-- Performing Test FLAG_SUPPORTED_Wcastalign - Success
-- Performing Test FLAG_SUPPORTED_Wformat2
-- Performing Test FLAG_SUPPORTED_Wformat2 - Success
-- Performing Test FLAG_SUPPORTED_Wmissingprototypes
-- Performing Test FLAG_SUPPORTED_Wmissingprototypes - Success
-- Performing Test FLAG_SUPPORTED_Wstrictoverflow2
-- Performing Test FLAG_SUPPORTED_Wstrictoverflow2 - Success
-- Performing Test FLAG_SUPPORTED_Wcastqual
-- Performing Test FLAG_SUPPORTED_Wcastqual - Success
-- Performing Test FLAG_SUPPORTED_Wundef
-- Performing Test FLAG_SUPPORTED_Wundef - Success
-- Performing Test FLAG_SUPPORTED_Wswitchdefault
-- Performing Test FLAG_SUPPORTED_Wswitchdefault - Success
-- Performing Test FLAG_SUPPORTED_Wconversion
-- Performing Test FLAG_SUPPORTED_Wconversion - Success
-- Performing Test FLAG_SUPPORTED_Wccompat
-- Performing Test FLAG_SUPPORTED_Wccompat - Success
-- Performing Test FLAG_SUPPORTED_fstackprotectorstrong
-- Performing Test FLAG_SUPPORTED_fstackprotectorstrong - Success
-- Performing Test FLAG_SUPPORTED_Wcomma
-- Performing Test FLAG_SUPPORTED_Wcomma - Failed
-- Performing Test FLAG_SUPPORTED_Wdoublepromotion
-- Performing Test FLAG_SUPPORTED_Wdoublepromotion - Success
-- Performing Test FLAG_SUPPORTED_Wparentheses
-- Performing Test FLAG_SUPPORTED_Wparentheses - Success
-- Performing Test FLAG_SUPPORTED_Wformatoverflow
-- Performing Test FLAG_SUPPORTED_Wformatoverflow - Success
-- Performing Test FLAG_SUPPORTED_Wunusedmacros
-- Performing Test FLAG_SUPPORTED_Wunusedmacros - Success
-- Performing Test FLAG_SUPPORTED_Wmissingvariabledeclarations
-- Performing Test FLAG_SUPPORTED_Wmissingvariabledeclarations - Failed
-- Performing Test FLAG_SUPPORTED_Wusedbutmarkedunused
-- Performing Test FLAG_SUPPORTED_Wusedbutmarkedunused - Failed
-- Performing Test FLAG_SUPPORTED_Wswitchenum
-- Performing Test FLAG_SUPPORTED_Wswitchenum - Success
-- Performing Test FLAG_SUPPORTED_fvisibilityhidden
-- Performing Test FLAG_SUPPORTED_fvisibilityhidden - Success
-- Configuring done
-- Generating done
-- Build files have been written to: /home/jeremy/GitHub/at_demos/demos/get_started_c/0-my-first-c-app/build
[  0%] Building C object _deps/cjson-build/CMakeFiles/cjson.dir/cJSON.c.o
[  0%] Linking C shared library libcjson.so
[  0%] Built target cjson
[  1%] Building C object _deps/atsdk-build/packages/atlogger/CMakeFiles/atlogger.dir/src/atlogger.c.o
[  1%] Linking C static library libatlogger.a
[  1%] Built target atlogger
[  2%] Building C object _deps/uuid4-build/CMakeFiles/uuid4-static.dir/src/uuid4.c.o
[  2%] Linking C static library libuuid4-static.a
[  2%] Built target uuid4-static
[  3%] Building C object _deps/mbedtls-build/3rdparty/everest/CMakeFiles/everest.dir/library/everest.c.o
[  3%] Building C object _deps/mbedtls-build/3rdparty/everest/CMakeFiles/everest.dir/library/x25519.c.o
[  3%] Building C object _deps/mbedtls-build/3rdparty/everest/CMakeFiles/everest.dir/library/Hacl_Curve25519_joined.c.o
[  4%] Linking C static library libeverest.a
[  4%] Built target everest
[  4%] Building C object _deps/mbedtls-build/3rdparty/p256-m/CMakeFiles/p256m.dir/p256-m_driver_entrypoints.c.o
[  5%] Building C object _deps/mbedtls-build/3rdparty/p256-m/CMakeFiles/p256m.dir/p256-m/p256-m.c.o
[  5%] Linking C static library libp256m.a
[  5%] Built target p256m
[  5%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/aes.c.o
[  5%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/aesni.c.o
[  6%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/aesce.c.o
[  6%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/aria.c.o
[  6%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/asn1parse.c.o
[  7%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/asn1write.c.o
[  7%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/base64.c.o
[  7%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/bignum.c.o
[  7%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/bignum_core.c.o
[  8%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/bignum_mod.c.o
[  8%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/bignum_mod_raw.c.o
[  8%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/camellia.c.o
[  9%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/ccm.c.o
[  9%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/chacha20.c.o
[  9%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/chachapoly.c.o
[ 10%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/cipher.c.o
[ 10%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/cipher_wrap.c.o
[ 10%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/constant_time.c.o
[ 10%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/cmac.c.o
[ 11%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/ctr_drbg.c.o
[ 11%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/des.c.o
[ 11%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/dhm.c.o
[ 12%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/ecdh.c.o
[ 12%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/ecdsa.c.o
[ 12%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/ecjpake.c.o
[ 13%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/ecp.c.o
[ 13%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/ecp_curves.c.o
[ 13%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/ecp_curves_new.c.o
[ 13%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/entropy.c.o
[ 14%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/entropy_poll.c.o
[ 14%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/error.c.o
[ 14%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/gcm.c.o
[ 15%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/hkdf.c.o
[ 15%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/hmac_drbg.c.o
[ 15%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/lmots.c.o
[ 16%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/lms.c.o
[ 16%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/md.c.o
[ 16%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/md5.c.o
[ 16%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/memory_buffer_alloc.c.o
[ 17%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/nist_kw.c.o
[ 17%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/oid.c.o
[ 17%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/padlock.c.o
[ 18%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/pem.c.o
[ 18%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/pk.c.o
[ 18%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/pk_wrap.c.o
[ 18%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/pkcs12.c.o
[ 19%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/pkcs5.c.o
[ 19%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/pkparse.c.o
[ 19%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/pkwrite.c.o
[ 20%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/platform.c.o
[ 20%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/platform_util.c.o
[ 20%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/poly1305.c.o
[ 21%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto.c.o
[ 21%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto_aead.c.o
[ 21%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto_cipher.c.o
[ 21%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto_client.c.o
[ 22%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto_driver_wrappers_no_static.c.o
[ 22%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto_ecp.c.o
[ 22%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto_ffdh.c.o
[ 23%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto_hash.c.o
[ 23%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto_mac.c.o
[ 23%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto_pake.c.o
[ 24%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto_rsa.c.o
[ 24%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto_se.c.o
[ 24%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto_slot_management.c.o
[ 24%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_crypto_storage.c.o
[ 25%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_its_file.c.o
[ 25%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/psa_util.c.o
[ 25%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/ripemd160.c.o
[ 26%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/rsa.c.o
[ 26%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/rsa_alt_helpers.c.o
[ 26%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/sha1.c.o
[ 27%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/sha256.c.o
[ 27%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/sha512.c.o
[ 27%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/sha3.c.o
[ 27%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/threading.c.o
[ 28%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/timing.c.o
[ 28%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/version.c.o
[ 28%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedcrypto.dir/version_features.c.o
[ 29%] Linking C static library libmbedcrypto.a
[ 29%] Built target mbedcrypto
[ 29%] Building C object _deps/atsdk-build/packages/atchops/CMakeFiles/atchops.dir/src/aes_ctr.c.o
[ 30%] Building C object _deps/atsdk-build/packages/atchops/CMakeFiles/atchops.dir/src/aes.c.o
[ 30%] Building C object _deps/atsdk-build/packages/atchops/CMakeFiles/atchops.dir/src/base64.c.o
[ 30%] Building C object _deps/atsdk-build/packages/atchops/CMakeFiles/atchops.dir/src/mbedtls.c.o
[ 31%] Building C object _deps/atsdk-build/packages/atchops/CMakeFiles/atchops.dir/src/iv.c.o
[ 31%] Building C object _deps/atsdk-build/packages/atchops/CMakeFiles/atchops.dir/src/rsa_key.c.o
[ 31%] Building C object _deps/atsdk-build/packages/atchops/CMakeFiles/atchops.dir/src/rsa.c.o
[ 31%] Building C object _deps/atsdk-build/packages/atchops/CMakeFiles/atchops.dir/src/sha.c.o
[ 32%] Building C object _deps/atsdk-build/packages/atchops/CMakeFiles/atchops.dir/src/uuid.c.o
[ 32%] Linking C static library libatchops.a
[ 32%] Built target atchops
[ 33%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedx509.dir/pkcs7.c.o
[ 33%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedx509.dir/x509.c.o
[ 33%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedx509.dir/x509_create.c.o
[ 34%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedx509.dir/x509_crl.c.o
[ 34%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedx509.dir/x509_crt.c.o
[ 34%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedx509.dir/x509_csr.c.o
[ 34%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedx509.dir/x509write.c.o
[ 35%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedx509.dir/x509write_crt.c.o
[ 35%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedx509.dir/x509write_csr.c.o
[ 35%] Linking C static library libmbedx509.a
[ 35%] Built target mbedx509
[ 35%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/debug.c.o
[ 35%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/mps_reader.c.o
[ 36%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/mps_trace.c.o
[ 36%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/net_sockets.c.o
[ 36%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_cache.c.o
[ 36%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_ciphersuites.c.o
[ 37%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_client.c.o
[ 37%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_cookie.c.o
[ 37%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_debug_helpers_generated.c.o
[ 38%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_msg.c.o
[ 38%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_ticket.c.o
[ 38%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_tls.c.o
[ 39%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_tls12_client.c.o
[ 39%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_tls12_server.c.o
[ 39%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_tls13_keys.c.o
[ 39%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_tls13_server.c.o
[ 40%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_tls13_client.c.o
[ 40%] Building C object _deps/mbedtls-build/library/CMakeFiles/mbedtls.dir/ssl_tls13_generic.c.o
[ 40%] Linking C static library libmbedtls.a
[ 40%] Built target mbedtls
[ 40%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atclient_delete.c.o
[ 41%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atclient_get_atkeys.c.o
[ 41%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atclient_get_public_key.c.o
[ 41%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atclient_get_self_key.c.o
[ 42%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atclient_get_shared_key.c.o
[ 42%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atclient_put_public_key.c.o
[ 42%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atclient_put_self_key.c.o
[ 42%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atclient_put_shared_key.c.o
[ 43%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atclient_utils.c.o
[ 43%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atclient.c.o
[ 43%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atkey.c.o
[ 44%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atkeys.c.o
[ 44%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atkeysfile.c.o
[ 44%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/atnotification.c.o
[ 45%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/connection_hooks.c.o
[ 45%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/connection.c.o
[ 45%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/encryption_key_helpers.c.o
[ 45%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/metadata.c.o
[ 46%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/monitor.c.o
/home/jeremy/GitHub/at_demos/demos/get_started_c/0-my-first-c-app/build/_deps/atsdk-src/packages/atclient/src/monitor.c: In function ‘parse_message’:
/home/jeremy/GitHub/at_demos/demos/get_started_c/0-my-first-c-app/build/_deps/atsdk-src/packages/atclient/src/monitor.c:251:19: warning: passing argument 1 of ‘strtok_r’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  251 |   temp = strtok_r(original, ":", &saveptr);
      |                   ^~~~~~~~
In file included from /home/jeremy/GitHub/at_demos/demos/get_started_c/0-my-first-c-app/build/_deps/atsdk-src/packages/atclient/src/monitor.c:17:
/usr/include/string.h:366:41: note: expected ‘char * restrict’ but argument is of type ‘const char *’
  366 | extern char *strtok_r (char *__restrict __s, const char *__restrict __delim,
      |                        ~~~~~~~~~~~~~~~~~^~~
[ 46%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/notify.c.o
[ 46%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/notify_params.c.o
[ 47%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/request_options.c.o
[ 47%] Building C object _deps/atsdk-build/packages/atclient/CMakeFiles/atclient.dir/src/string_utils.c.o
[ 47%] Linking C static library libatclient.a
[ 47%] Built target atclient
[ 47%] Building C object CMakeFiles/main.dir/main.c.o
[ 48%] Linking C executable main
[ 48%] Built target main
[ 49%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/asn1_helpers.c.o
[ 49%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/bignum_helpers.c.o
[ 49%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/certs.c.o
[ 50%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/drivers/hash.c.o
[ 50%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/drivers/platform_builtin_keys.c.o
[ 50%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/drivers/test_driver_aead.c.o
[ 50%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/drivers/test_driver_asymmetric_encryption.c.o
[ 51%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/drivers/test_driver_cipher.c.o
[ 51%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/drivers/test_driver_key_agreement.c.o
[ 51%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/drivers/test_driver_key_management.c.o
[ 52%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/drivers/test_driver_mac.c.o
[ 52%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/drivers/test_driver_pake.c.o
[ 52%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/drivers/test_driver_signature.c.o
[ 53%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/fake_external_rng_for_test.c.o
[ 53%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/helpers.c.o
[ 53%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/psa_crypto_helpers.c.o
[ 53%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/psa_exercise_key.c.o
[ 54%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/random.c.o
[ 54%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test.dir/tests/src/threading_helpers.c.o
[ 54%] Built target mbedtls_test
[ 54%] Building C object _deps/mbedtls-build/CMakeFiles/mbedtls_test_helpers.dir/tests/src/test_helpers/ssl_helpers.c.o
[ 54%] Built target mbedtls_test_helpers
[ 54%] Building C object _deps/mbedtls-build/programs/aes/CMakeFiles/crypt_and_hash.dir/crypt_and_hash.c.o
[ 55%] Linking C executable crypt_and_hash
[ 55%] Built target crypt_and_hash
[ 56%] Building C object _deps/mbedtls-build/programs/cipher/CMakeFiles/cipher_aead_demo.dir/cipher_aead_demo.c.o
[ 56%] Linking C executable cipher_aead_demo
[ 56%] Built target cipher_aead_demo
[ 57%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_pubkey.dir/fuzz_pubkey.c.o
[ 57%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_pubkey.dir/onefile.c.o
[ 57%] Linking C executable fuzz_pubkey
[ 57%] Built target fuzz_pubkey
[ 58%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_x509crl.dir/fuzz_x509crl.c.o
[ 58%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_x509crl.dir/onefile.c.o
[ 58%] Linking C executable fuzz_x509crl
[ 58%] Built target fuzz_x509crl
[ 59%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_x509crt.dir/fuzz_x509crt.c.o
[ 59%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_x509crt.dir/onefile.c.o
[ 59%] Linking C executable fuzz_x509crt
[ 59%] Built target fuzz_x509crt
[ 60%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_x509csr.dir/fuzz_x509csr.c.o
[ 60%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_x509csr.dir/onefile.c.o
[ 60%] Linking C executable fuzz_x509csr
[ 60%] Built target fuzz_x509csr
[ 61%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_pkcs7.dir/fuzz_pkcs7.c.o
[ 61%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_pkcs7.dir/onefile.c.o
[ 61%] Linking C executable fuzz_pkcs7
[ 61%] Built target fuzz_pkcs7
[ 61%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_privkey.dir/fuzz_privkey.c.o
[ 62%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_privkey.dir/onefile.c.o
[ 62%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_privkey.dir/common.c.o
[ 62%] Linking C executable fuzz_privkey
[ 62%] Built target fuzz_privkey
[ 62%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_client.dir/fuzz_client.c.o
[ 62%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_client.dir/onefile.c.o
[ 63%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_client.dir/common.c.o
[ 63%] Linking C executable fuzz_client
[ 63%] Built target fuzz_client
[ 63%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_dtlsclient.dir/fuzz_dtlsclient.c.o
[ 63%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_dtlsclient.dir/onefile.c.o
[ 64%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_dtlsclient.dir/common.c.o
[ 64%] Linking C executable fuzz_dtlsclient
[ 64%] Built target fuzz_dtlsclient
[ 64%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_dtlsserver.dir/fuzz_dtlsserver.c.o
[ 65%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_dtlsserver.dir/onefile.c.o
[ 65%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_dtlsserver.dir/common.c.o
[ 65%] Linking C executable fuzz_dtlsserver
[ 65%] Built target fuzz_dtlsserver
[ 66%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_server.dir/fuzz_server.c.o
[ 66%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_server.dir/onefile.c.o
[ 66%] Building C object _deps/mbedtls-build/programs/fuzz/CMakeFiles/fuzz_server.dir/common.c.o
[ 66%] Linking C executable fuzz_server
[ 66%] Built target fuzz_server
[ 66%] Building C object _deps/mbedtls-build/programs/hash/CMakeFiles/generic_sum.dir/generic_sum.c.o
[ 67%] Linking C executable generic_sum
[ 67%] Built target generic_sum
[ 67%] Building C object _deps/mbedtls-build/programs/hash/CMakeFiles/hello.dir/hello.c.o
[ 67%] Linking C executable hello
[ 67%] Built target hello
[ 68%] Building C object _deps/mbedtls-build/programs/hash/CMakeFiles/md_hmac_demo.dir/md_hmac_demo.c.o
[ 68%] Linking C executable md_hmac_demo
[ 68%] Built target md_hmac_demo
[ 69%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/dh_client.dir/dh_client.c.o
[ 69%] Linking C executable dh_client
[ 69%] Built target dh_client
[ 70%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/dh_server.dir/dh_server.c.o
[ 70%] Linking C executable dh_server
[ 70%] Built target dh_server
[ 70%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/dh_genprime.dir/dh_genprime.c.o
[ 70%] Linking C executable dh_genprime
[ 70%] Built target dh_genprime
[ 71%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/ecdh_curve25519.dir/ecdh_curve25519.c.o
[ 71%] Linking C executable ecdh_curve25519
[ 71%] Built target ecdh_curve25519
[ 71%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/ecdsa.dir/ecdsa.c.o
[ 71%] Linking C executable ecdsa
[ 71%] Built target ecdsa
[ 71%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/gen_key.dir/gen_key.c.o
[ 71%] Linking C executable gen_key
[ 71%] Built target gen_key
[ 71%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/key_app.dir/key_app.c.o
[ 71%] Linking C executable key_app
[ 71%] Built target key_app
[ 72%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/key_app_writer.dir/key_app_writer.c.o
[ 72%] Linking C executable key_app_writer
[ 72%] Built target key_app_writer
[ 72%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/mpi_demo.dir/mpi_demo.c.o
[ 72%] Linking C executable mpi_demo
[ 72%] Built target mpi_demo
[ 73%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/pk_encrypt.dir/pk_encrypt.c.o
[ 73%] Linking C executable pk_encrypt
[ 73%] Built target pk_encrypt
[ 73%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/pk_decrypt.dir/pk_decrypt.c.o
[ 73%] Linking C executable pk_decrypt
[ 73%] Built target pk_decrypt
[ 73%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/pk_sign.dir/pk_sign.c.o
[ 73%] Linking C executable pk_sign
[ 73%] Built target pk_sign
[ 74%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/pk_verify.dir/pk_verify.c.o
[ 74%] Linking C executable pk_verify
[ 74%] Built target pk_verify
[ 74%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/rsa_decrypt.dir/rsa_decrypt.c.o
[ 74%] Linking C executable rsa_decrypt
[ 74%] Built target rsa_decrypt
[ 75%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/rsa_encrypt.dir/rsa_encrypt.c.o
[ 75%] Linking C executable rsa_encrypt
[ 75%] Built target rsa_encrypt
[ 75%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/rsa_genkey.dir/rsa_genkey.c.o
[ 76%] Linking C executable rsa_genkey
[ 76%] Built target rsa_genkey
[ 76%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/rsa_sign.dir/rsa_sign.c.o
[ 76%] Linking C executable rsa_sign
[ 76%] Built target rsa_sign
[ 76%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/rsa_sign_pss.dir/rsa_sign_pss.c.o
[ 77%] Linking C executable rsa_sign_pss
[ 77%] Built target rsa_sign_pss
[ 77%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/rsa_verify.dir/rsa_verify.c.o
[ 77%] Linking C executable rsa_verify
[ 77%] Built target rsa_verify
[ 78%] Building C object _deps/mbedtls-build/programs/pkey/CMakeFiles/rsa_verify_pss.dir/rsa_verify_pss.c.o
[ 78%] Linking C executable rsa_verify_pss
[ 78%] Built target rsa_verify_pss
[ 78%] Building C object _deps/mbedtls-build/programs/psa/CMakeFiles/aead_demo.dir/aead_demo.c.o
[ 78%] Linking C executable aead_demo
[ 78%] Built target aead_demo
[ 78%] Building C object _deps/mbedtls-build/programs/psa/CMakeFiles/crypto_examples.dir/crypto_examples.c.o
[ 78%] Linking C executable crypto_examples
[ 78%] Built target crypto_examples
[ 78%] Building C object _deps/mbedtls-build/programs/psa/CMakeFiles/hmac_demo.dir/hmac_demo.c.o
[ 79%] Linking C executable hmac_demo
[ 79%] Built target hmac_demo
[ 79%] Building C object _deps/mbedtls-build/programs/psa/CMakeFiles/key_ladder_demo.dir/key_ladder_demo.c.o
[ 80%] Linking C executable key_ladder_demo
[ 80%] Built target key_ladder_demo
[ 80%] Building C object _deps/mbedtls-build/programs/psa/CMakeFiles/psa_constant_names.dir/psa_constant_names.c.o
[ 81%] Linking C executable psa_constant_names
[ 81%] Built target psa_constant_names
[ 81%] Building C object _deps/mbedtls-build/programs/random/CMakeFiles/gen_entropy.dir/gen_entropy.c.o
[ 82%] Linking C executable gen_entropy
[ 82%] Built target gen_entropy
[ 83%] Building C object _deps/mbedtls-build/programs/random/CMakeFiles/gen_random_ctr_drbg.dir/gen_random_ctr_drbg.c.o
[ 83%] Linking C executable gen_random_ctr_drbg
[ 83%] Built target gen_random_ctr_drbg
[ 83%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/dtls_client.dir/dtls_client.c.o
[ 84%] Linking C executable dtls_client
[ 84%] Built target dtls_client
[ 84%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/dtls_server.dir/dtls_server.c.o
[ 84%] Linking C executable dtls_server
[ 84%] Built target dtls_server
[ 84%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/mini_client.dir/mini_client.c.o
[ 85%] Linking C executable mini_client
[ 85%] Built target mini_client
[ 85%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/ssl_client1.dir/ssl_client1.c.o
[ 85%] Linking C executable ssl_client1
[ 85%] Built target ssl_client1
[ 85%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/ssl_client2.dir/ssl_client2.c.o
[ 86%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/ssl_client2.dir/ssl_test_lib.c.o
[ 86%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/ssl_client2.dir/__/test/query_config.c.o
[ 86%] Linking C executable ssl_client2
[ 86%] Built target ssl_client2
[ 87%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/ssl_context_info.dir/ssl_context_info.c.o
[ 87%] Linking C executable ssl_context_info
[ 87%] Built target ssl_context_info
[ 87%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/ssl_fork_server.dir/ssl_fork_server.c.o
[ 88%] Linking C executable ssl_fork_server
[ 88%] Built target ssl_fork_server
[ 88%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/ssl_mail_client.dir/ssl_mail_client.c.o
[ 88%] Linking C executable ssl_mail_client
[ 88%] Built target ssl_mail_client
[ 88%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/ssl_server.dir/ssl_server.c.o
[ 88%] Linking C executable ssl_server
[ 88%] Built target ssl_server
[ 89%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/ssl_server2.dir/ssl_server2.c.o
[ 89%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/ssl_server2.dir/ssl_test_lib.c.o
[ 89%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/ssl_server2.dir/__/test/query_config.c.o
[ 90%] Linking C executable ssl_server2
[ 90%] Built target ssl_server2
[ 90%] Building C object _deps/mbedtls-build/programs/ssl/CMakeFiles/ssl_pthread_server.dir/ssl_pthread_server.c.o
[ 91%] Linking C executable ssl_pthread_server
[ 91%] Built target ssl_pthread_server
[ 91%] Building C object _deps/mbedtls-build/programs/test/CMakeFiles/query_included_headers.dir/query_included_headers.c.o
[ 91%] Linking C executable query_included_headers
[ 91%] Built target query_included_headers
[ 91%] Building C object _deps/mbedtls-build/programs/test/CMakeFiles/selftest.dir/selftest.c.o
[ 92%] Linking C executable selftest
[ 92%] Built target selftest
[ 92%] Building C object _deps/mbedtls-build/programs/test/CMakeFiles/udp_proxy.dir/udp_proxy.c.o
[ 93%] Linking C executable udp_proxy
[ 93%] Built target udp_proxy
[ 93%] Building C object _deps/mbedtls-build/programs/test/CMakeFiles/benchmark.dir/benchmark.c.o
[ 93%] Linking C executable benchmark
[ 93%] Built target benchmark
[ 93%] Building C object _deps/mbedtls-build/programs/test/CMakeFiles/query_compile_time_config.dir/query_compile_time_config.c.o
[ 93%] Building C object _deps/mbedtls-build/programs/test/CMakeFiles/query_compile_time_config.dir/query_config.c.o
[ 94%] Linking C executable query_compile_time_config
[ 94%] Built target query_compile_time_config
[ 94%] Building C object _deps/mbedtls-build/programs/test/CMakeFiles/zeroize.dir/zeroize.c.o
[ 95%] Linking C executable zeroize
[ 95%] Built target zeroize
[ 95%] Building C object _deps/mbedtls-build/programs/util/CMakeFiles/pem2der.dir/pem2der.c.o
[ 96%] Linking C executable pem2der
[ 96%] Built target pem2der
[ 96%] Building C object _deps/mbedtls-build/programs/util/CMakeFiles/strerror.dir/strerror.c.o
[ 96%] Linking C executable strerror
[ 96%] Built target strerror
[ 97%] Building C object _deps/mbedtls-build/programs/x509/CMakeFiles/cert_app.dir/cert_app.c.o
[ 97%] Linking C executable cert_app
[ 97%] Built target cert_app
[ 97%] Building C object _deps/mbedtls-build/programs/x509/CMakeFiles/cert_req.dir/cert_req.c.o
[ 98%] Linking C executable cert_req
[ 98%] Built target cert_req
[ 98%] Building C object _deps/mbedtls-build/programs/x509/CMakeFiles/cert_write.dir/cert_write.c.o
[ 98%] Linking C executable cert_write
[ 98%] Built target cert_write
[ 99%] Building C object _deps/mbedtls-build/programs/x509/CMakeFiles/crl_app.dir/crl_app.c.o
[ 99%] Linking C executable crl_app
[ 99%] Built target crl_app
[ 99%] Building C object _deps/mbedtls-build/programs/x509/CMakeFiles/load_roots.dir/load_roots.c.o
[ 99%] Linking C executable load_roots
[ 99%] Built target load_roots
[ 99%] Building C object _deps/mbedtls-build/programs/x509/CMakeFiles/req_app.dir/req_app.c.o
[100%] Linking C executable req_app
[100%] Built target req_app
[100%] Building C object _deps/uuid4-build/CMakeFiles/uuid4-shared.dir/src/uuid4.c.o
[100%] Linking C shared library libuuid4-shared.so
[100%] Built target uuid4-shared
[DEBG] 2024-08-19 18:27:14.380251 | connection |        SENT: "jeremy_0"
[DEBG] 2024-08-19 18:27:14.414908 | connection |        RECV: "3b419d7a-2fee-5080-9289-f0e1853abb47.swarm0002.atsign.zone:5770"
[DEBG] 2024-08-19 18:27:14.806050 | connection |        SENT: "from:jeremy_0"
[DEBG] 2024-08-19 18:27:14.842102 | connection |        RECV: "data:_5a0e30b8-9771-4391-b9d9-2f4aabdcec0b@jeremy_0:b1d3d6b4-3f47-4c36-a07f-795c4e5911fb"
[DEBG] 2024-08-19 18:27:14.881782 | connection |        SENT: "pkam:CgeMxyZMuC5xmXXlraZgR3AC0Y5ZAghENhdBIKVyqPQnaQULc242YUKaBNQoUYVqE8MQ554WZEBW9GytaBn6OXAr2BihS/HlH3S99ULYb0MMjm9/shCodJeCPbsWYaLwMjsVschh52TolJQIJp9G0REt30tSRzDLIC+uyzz0OaYbNPwE+EtpqTU4Zq7EY5Ckw4vDzIdykYhb2kmhhvh/7MqTpN2LbRu3+OUh5bD1X7gVLNttRbxQxzpIldIEzyO6pvpkqbhLk0lvR/hbUEIQQoKf3+5Bu9f/0Cahs+jK2LwQeC/mc2Ksp5LLwwpysSTrQxorbP2GO5Kvew63fuxrtQ=="
[DEBG] 2024-08-19 18:27:14.924044 | connection |        RECV: "data:success"
[INFO] 2024-08-19 18:27:14.924090 | my_first_c_app | Authenticated to atServer successfully!
jeremy@raspberrypi8:~/GitHub/at_demos/demos/get_started_c/0-my-first-c-app $ 
```

And everything works good

**- Description for the changelog**
feat: update CMakeLists.txt
