### PR TITLE
build(deps): Bump osv-scanner to v2.2.1

### DIFF
--- a/.github/workflows/static_analysis.yml
+++ b/.github/workflows/static_analysis.yml
@@ -57,7 +57,7 @@ jobs:
       # placed here, as the `dart pub get` above will create them
       - name: Run osv-scanner
         run: |
-          go install github.com/google/osv-scanner/cmd/osv-scanner@6316373e47d7e3e4b4fd3630c4bbc10987738de6 # v1.4.3
+          go install github.com/google/osv-scanner/v2/cmd/osv-scanner@04a8728383d8f286cf2b0f110e68482e8773df6e # v2.2.1
           osv-scanner --lockfile=./demos/mwc_demo/dart/iot_sender/pubspec.lock
           osv-scanner --lockfile=./demos/at_notifications/pubspec.lock
           osv-scanner --lockfile=./packages/at_demo_data/pubspec.lock


### PR DESCRIPTION
osv-scanner v1.4.3 seems to break with Go 1.25.0

**- What I did**

Bumped osv-scanner to latest (v2.2.1)

**- How to verify it**

CI

**- Description for the changelog**

build(deps): Bump osv-scanner to v2.2.1
